### PR TITLE
Show raw semver on compose-cd version

### DIFF
--- a/compose-cd
+++ b/compose-cd
@@ -21,11 +21,11 @@ function compose() {
 function version() {
 	local compose_cd_ver
 
-	compose_cd_ver="v${COMPOSE_CD_VER_MAJOR}.${COMPOSE_CD_VER_MINOR}.${COMPOSE_CD_VER_PATCH}"
+	compose_cd_ver="${COMPOSE_CD_VER_MAJOR}.${COMPOSE_CD_VER_MINOR}.${COMPOSE_CD_VER_PATCH}"
 	if [ -n "${COMPOSE_CD_VER_PRE}" ]; then
 		compose_cd_ver="${compose_cd_ver}-${COMPOSE_CD_VER_PRE}"
 	fi
-	echo "version: ${compose_cd_ver}"
+	echo "${compose_cd_ver}"
 }
 
 function usage() {


### PR DESCRIPTION
- `compose-cd version` では `v` prefix や `version: ` のような余計な文字列を付けず，生の semver を出力するようにする
  - そもそも `v` prefix が付いた文字列は semver ではない（tag としては使っているが）
  - #142 などでの自動化に使うには不便だった