### PR TITLE
CUSTOM_UP_COMMAND and SERVICE_UP_ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,27 @@ At first glance, updating this configuration may seem to be very tedious, but it
 Example:
   - https://github.com/sksat/mc.yohane.su/pull/232
 
+
+### How to inject secrets from a password manager
+
+If you are using a password manager like 1Password, you can instruct compose-cd to use an alternate command to bring up the docker-compose stack.
+
+```
+CUSTOM_UP_COMMAND=op run --env-file=.env -- docker compose up -d
+```
+
+Then within each docker-compose stack you can create .env file with your configuration values.
+
+```
+POSTGRES_SERVER="op://vault-name/coder/database/server"
+POSTGRES_DB="op://vault-name/coder/database/db"
+POSTGRES_USER="op://vault-name/coder/database/user"
+POSTGRES_USER_PW="op://vault-name/coder/database/password"
+```
+
+Following the [secrets-reference-syntax](https://developer.1password.com/docs/cli/secrets-reference-syntax/), these configuration items and secrets will be supplies whenever the docker compose stack is recreated, and the secrets never have to hit the filesystem or your monorepo (except of course in the container definition files...).
+
+
 ## Blog
 - [マイクラサーバをGitHubで運用する](https://sksat.hatenablog.com/entry/2021/08/26/015620)
 

--- a/compose-cd
+++ b/compose-cd
@@ -522,7 +522,7 @@ function foreach_project() {
 
 			(
 				cd "$proj" || {
-					compose_log echo "[$proj] error: project not fouund"
+					compose_log echo "[$proj] error: project not found"
 					exit 1
 				}
 				eval "$1 $proj"

--- a/compose-cd
+++ b/compose-cd
@@ -133,6 +133,10 @@ function load_config() {
 		compose_log echo "config file not found"
 		return
 	fi
+
+	# Clear the CUSTOM_UP_COMMAND variable at the beginning of each iteration
+    unset CUSTOM_UP_COMMAND
+
 	# shellcheck disable=SC1091
 	source ./.compose-cd # super config system
 	if [ -z ${UPDATE_REPO_ONLY+x} ]; then UPDATE_REPO_ONLY=false; fi
@@ -162,19 +166,28 @@ function load_config() {
 		exit 1
 	fi
 
+	if "$CUSTOM_UP_COMMAND" && "$RESTART_WITH_BUILD"; then
+		compose_log echo "CUSTOM_UP_COMMAND and RESTART_WITH_BUILD are both populated. CUSTOM_UP_COMMAND overrides all other build options."
+		exit 1
+	fi
+
 	compose_log echo "ok"
 	return $ret
 }
 
 function service_up() {
 	compose_log notify "starting service..."
-	if ! "$RESTART_WITH_BUILD"; then
-		compose up -d 2>/dev/null
-	else
-		compose_log notify "start build..."
-		compose up -d --build 2>/dev/null
-		compose_log notify "finish build"
-	fi
+
+	if [ -n "${CUSTOM_UP_COMMAND}" ]; then
+            eval "$CUSTOM_UP_COMMAND"
+        else
+			if ! "$RESTART_WITH_BUILD"; then
+				compose up -d 2>/dev/null
+			else
+				compose_log notify "start build..."
+				compose up -d --build 2>/dev/null
+				compose_log notify "finish build"
+			fi
 	compose_log notify "service is up!"
 }
 

--- a/compose-cd
+++ b/compose-cd
@@ -141,6 +141,7 @@ function load_config() {
 	source ./.compose-cd # super config system
 	if [ -z ${UPDATE_REPO_ONLY+x} ]; then UPDATE_REPO_ONLY=false; fi
 	if [ -z ${UPDATE_IMAGE_ONLY+x} ]; then UPDATE_IMAGE_ONLY=false; fi
+	if [ -z ${SERVICE_UP_ONLY+x} ]; then SERVICE_UP_ONLY=false; fi
 
 	if [ -z ${UPDATE_IMAGE_BY_REPO+x} ]; then UPDATE_IMAGE_BY_REPO=false; fi
 
@@ -462,7 +463,12 @@ function project_update() {
 	# todo: running check
 
 	compose_log echo "restart service..."
-	service_down
+
+	if ! "$SERVICE_UP_ONLY"; then
+		compose_log echo "restart service..."
+		service_down
+	fi
+
 	service_up
 
 	# after script

--- a/compose-cd
+++ b/compose-cd
@@ -166,7 +166,7 @@ function load_config() {
 		exit 1
 	fi
 
-	if "$CUSTOM_UP_COMMAND" && "$RESTART_WITH_BUILD"; then
+	if [ -z "${CUSTOM_UP_COMMAND+x}" ] && [ -z "${RESTART_WITH_BUILD+x}" ]; then
 		compose_log echo "CUSTOM_UP_COMMAND and RESTART_WITH_BUILD are both populated. CUSTOM_UP_COMMAND overrides all other build options."
 		exit 1
 	fi
@@ -188,6 +188,7 @@ function service_up() {
 				compose up -d --build 2>/dev/null
 				compose_log notify "finish build"
 			fi
+	fi
 	compose_log notify "service is up!"
 }
 


### PR DESCRIPTION
Two additions:


### CUSTOM_UP_COMMAND

If `CUSTOM_UP_COMMAND` is included in `.compose-cd`, then instead of running the normal `docker compose up -d` command within the directory, an alternate command can be supplied.
This is useful when using a secrets manager or injecting other .envs. 

Documentation on this use case has been added to the `README.md`.


### SERVICE_UP_ONLY

If `.compose-cd` includes `SERVICE_UP_ONLY=true`, then docker compose will not bring down the containers.

This is useful for example if you are running traefik as a compose-cd managed stack, and it is also used to expose the secrets store (Vault, 1Password Connect, etc.. If you take the stack down then compose-cd will be unable to resolve the secrets needed to bring it back online.