### PR TITLE
fix: Fix broken links in local and remote repositories

### DIFF
--- a/compose-cd
+++ b/compose-cd
@@ -274,10 +274,12 @@ function update_repo() {
 	fi
 
 	compose_log echo "pull start"
+	local local_commit_url
 	local local_commit_link
 	local remote_commit_link
-	local_commit_link="[$local_commit]($(git remote get-url "${git_remote}")/commit/${local_commit})"
-	remote_commit_link="[$remote_commit]($(git remote get-url "${git_remote}")/commit/${remote_commit})"
+	local_commit_url=$(git remote get-url "${git_remote}" | sed 's/\.git$//')
+	local_commit_link="[$local_commit](${local_commit_url}/commit/${local_commit})"
+	remote_commit_link="[$remote_commit](${local_commit_url}/commit/${remote_commit})"
 	compose_log notify "local(${local_commit_link}) -> remote(${remote_commit_link})"
 
 	git pull "${git_remote}" "$branch"


### PR DESCRIPTION
Fixed broken links by removing `.git` prefix from remote and local commit links used in webhooks
(GitHub does not automatically redirect links with `.git` prefixes, but instead returns a 404 error.)

![CleanShot 2025-07-07 at 14 48 51@2x](https://github.com/user-attachments/assets/ce878c57-5065-4632-b2d9-00ac6fbd429c)
